### PR TITLE
fix:make-inputs-style-inline

### DIFF
--- a/src/components/FeatureCard/index.tsx
+++ b/src/components/FeatureCard/index.tsx
@@ -7,7 +7,7 @@ function index({ feature }: { feature: IFeature }) {
             <h1 className="text-3xl font-bold">{feature.title}</h1>
             <p className="my-4 text-lg font-medium">{feature.description}</p>
             <ul className="pl-4">
-                {feature.subFeatures.map((sf: any) => {
+                {feature.subFeatures.map((sf: string) => {
                     return (
                         <li className="flex flex-row items-center gap-4 text-base font-medium" key={sf}>
                             <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16">

--- a/src/components/HeroSection/index.tsx
+++ b/src/components/HeroSection/index.tsx
@@ -4,9 +4,13 @@ export default function HeroSection({ data }: { data: IHeroConfig }) {
 
     return (
         <section
-            className={`w-full min-h-[${data.maxHeight}] bg-[url('${data.coverPath}')] ${data.height && `h-[${data.height}]`}  bg-cover flex justify-center items-center`}
+            className={`w-full   bg-cover flex justify-center items-center`}
+            style={{
+                backgroundImage: `url('${data.coverPath}')`,
+                height: data.height ? data.height : 'inherit',
+                minHeight: data.maxHeight
 
-        >
+            }}        >
             <div className="flex items-center justify-center w-full h-full text-center text-white">
                 <div className="font-primary">
                     {data.renderContent()}


### PR DESCRIPTION
Change the inputs for the shared HeroSection component, from using Tailwind CSS classes directly to using inline styles instead.