### PR TITLE
feat:add-responsive-home-page

### DIFF
--- a/src/components/ContactUsSection/index.tsx
+++ b/src/components/ContactUsSection/index.tsx
@@ -10,19 +10,24 @@ export default function ContactUsSection() {
     returnObjects: true,
   }) as locationProps[];
   return (
-    <section id="contact-us">
+    <section id="contact-us" className="lg:max-h-[500px] ">
       <CentredLayout>
-        <div className="flex flex-col gap-8">
-          <div className="flex flex-row gap-6 bg-[url('/images/cover.jpg')] bg-cover bg-center rounded-2xl  relative shadow-2xl ">
+        <div className="flex flex-col gap-8 lg:px-0">
+          <div className="flex flex-row gap-6 bg-[url('/images/cover.jpg')] bg-cover bg-center  lg:rounded-2xl   relative shadow-2xl  min-h-[300px] lg:min-h-full ">
             <div className="absolute inset-0 z-0 bg-black opacity-50 rounded-2xl"></div>
 
-            <div className="z-10 flex flex-col justify-center w-2/3 gap-6 p-8">
-              <h1 className="text-5xl text-white">{t("contactUs.title")}</h1>
-              <p className="text-base text-white">
+            <div className="z-10 flex flex-col justify-center gap-6 p-8 lg:w-2/3">
+              <h1 className="hidden text-5xl text-white lg:block">
+                {t("contactUs.title")}
+              </h1>
+              <p className="hidden text-base text-white lg:block">
                 {t("contactUs.description")}
               </p>
-              <p className="text-white"> {t("contactUs.locationQuestion")}</p>
-              <ul className="space-y-2 text-white">
+              <p className="hidden text-white lg:block">
+                {" "}
+                {t("contactUs.locationQuestion")}
+              </p>
+              <ul className="hidden space-y-2 text-white lg:block">
                 {location.map((element: locationProps, index: number) => (
                   <li className="flex flex-row items-center gap-3" key={index}>
                     <FaArrowRightLong />
@@ -34,7 +39,7 @@ export default function ContactUsSection() {
                 ))}
               </ul>
             </div>
-            <div className="absolute w-1/3 p-6 bg-white shadow-2xl right-5 top-10 rounded-2xl">
+            <div className="absolute w-[90%]  p-6 translate-x-1/2 lg:translate-x-0  bg-white shadow-2xl lg:w-1/3 lg:right-5  right-1/2 top-10 rounded-2xl">
               <ContactUsForm t={t} />
             </div>
           </div>

--- a/src/components/TextileErpFeatures/index.tsx
+++ b/src/components/TextileErpFeatures/index.tsx
@@ -19,13 +19,18 @@ export default function TextileErpFeatures() {
     <section id="textile-features">
       <CentredLayout>
         {sectionsData.map((element: subSectionsProps, index: number) => (
-          <div className={cn("flex flex-col gap-16", index !== 0 && "mt-32")}>
-            <div className="flex flex-col w-4/5 gap-8">
-              <div className="text-5xl font-bold text-left ">
-                <h1 className="block text-black opacity-70 dark:text-white">
+          <div
+            className={cn(
+              "flex flex-col gap-16 px-4 lg:px-0",
+              index !== 0 && "mt-32"
+            )}
+          >
+            <div className="flex flex-col gap-8 lg:w-4/5">
+              <div className="text-3xl font-bold text-left lg:text-5xl ">
+                <h1 className="block text-black dark:text-white">
                   {element.subsectionTitle.title}
                 </h1>
-                <h1 className="text-left text-black opacity-70 dark:text-slate-300">
+                <h1 className="text-left text-black dark:text-white">
                   {element.subsectionTitle.grayTitle}
                 </h1>
               </div>
@@ -34,7 +39,7 @@ export default function TextileErpFeatures() {
               </p>
             </div>
 
-            <div className="grid gap-6 advantagesCardGrid">
+            <div className="grid gap-6 grid-cols-1 lg:grid-cols-[repeat(auto-fill,_minmax(500px,_1fr))]">
               {element.cards.map(
                 (item: featuresCardProps | solutionCardProps, idx: number) =>
                   index === 0 ? (

--- a/src/components/featuresSection/index.tsx
+++ b/src/components/featuresSection/index.tsx
@@ -16,9 +16,9 @@ export default function FeaturesSection() {
   return (
     <section id="features-section">
       <CentredLayout>
-        <div className="flex flex-col gap-6">
-          <div className="flex items-center justify-between ">
-            <h1 className="text-5xl font-semibold leading-relaxed">
+        <div className="flex flex-col gap-6 px-4 lg:px:0">
+          <div className="flex flex-col items-center justify-between gap-3 lg:flex-row ">
+            <h1 className="text-3xl font-semibold leading-relaxed text-center lg:text-start lg:text-5xl">
               {t("featuresSection.sectionTitle")}
             </h1>
             <Button
@@ -28,12 +28,12 @@ export default function FeaturesSection() {
               Voir Plus
             </Button>
           </div>
-          <div className="grid gap-6 sharedGrid">
+          <div className="grid gap-6 grid-cols-1 lg:grid-cols-[500px_1fr]">
             {featuresCol1.map((element: featuresProps, index: number) => (
               <FeaturesCard element={element} index={index} />
             ))}
           </div>
-          <div className="grid gap-6 secondGrid">
+          <div className="grid gap-6 grid-cols-1 lg:grid-cols-[1fr_500px]">
             {featuresCol2.map((element: featuresProps, index: number) => (
               <FeaturesCard element={element} index={index} />
             ))}

--- a/src/components/heroSection/index.tsx
+++ b/src/components/heroSection/index.tsx
@@ -22,17 +22,17 @@ export default function HeroSection() {
   };
 
   return (
-    <section id="hero-section" className="max-h-[900px]">
+    <section id="hero-section" className="lg:max-h-[900px]">
       <CentredLayout>
-        <div className="flex flex-row gap-8">
+        <div className="flex flex-row gap-8 px-4 lg:px-0">
           <div>
             <Navbar />
-            <div className="flex flex-col h-full justify-evenly">
-              <h1 className="text-6xl font-bold leading-tight">
+            <div className="flex flex-col h-full gap-6 lg:gap-0 justify-evenly">
+              <h1 className="text-3xl font-bold leading-tight text-center lg:text-start lg:text-6xl">
                 {t("heroSection.title")}
               </h1>
 
-              <div className="flex flex-col gap-6">
+              <div className="flex flex-col items-center gap-6 lg:items-start">
                 <p className="text-sm font-light text-gray-800 dark:text-white">
                   {t("heroSection.paragraph")}
                 </p>
@@ -46,7 +46,7 @@ export default function HeroSection() {
             </div>
           </div>
 
-          <div className="max-w-[600px]">
+          <div className="hidden lg:block lg:max-w-xl ">
             <Slider {...settings}>
               {swiperImages.map(
                 (element: { src: string; alt: string }, index: number) => (

--- a/src/components/ourClients/index.tsx
+++ b/src/components/ourClients/index.tsx
@@ -13,7 +13,7 @@ export default function OurClients() {
       <CenteredLayout>
         <div className="flex flex-col gap-6 lg:flex-row">
           <div className="">
-            <h1 className="pb-3 text-4xl font-semibold leading-normal text-left text-white lg:text-6xl">
+            <h1 className="pb-3 text-3xl font-semibold leading-normal text-left text-white lg:text-6xl">
               {t("ourClients.title")}
             </h1>
             <p className="mt-2 leading-8 text-white lg:text-lg text-md muted ">

--- a/src/components/partials/footer/index.tsx
+++ b/src/components/partials/footer/index.tsx
@@ -12,7 +12,7 @@ export default function Footer() {
   }) as FooterItems[];
 
   return (
-    <footer className="dark:bg-[#161616] bg-black py-8 mt-36">
+    <footer className="dark:bg-[#161616] bg-black py-8 mt-[393.2px] lg:mt-[301.2px]">
       <CenteredLayout>
         <div className="flex flex-col justify-between w-full lg:flex-row">
           <div className="max-w-full items-start lg:max-w-[40%] flex flex-col gap-4 ">
@@ -22,7 +22,7 @@ export default function Footer() {
             </p>
             <ThemeToggler />
           </div>
-          <div className="flex flex-row justify-around gap-8 pt-10 lg:pt-0">
+          <div className="flex flex-col items-center justify-center gap-8 pt-10 lg:justify-around lg:flex-row lg:pt-0">
             {footerSiteMap.map((element: FooterItems, index: number) => (
               <div key={index}>
                 <h1 className="text-lg font-semibold text-white">

--- a/src/components/partials/navbar/desktop/index.tsx
+++ b/src/components/partials/navbar/desktop/index.tsx
@@ -1,0 +1,42 @@
+import { Link } from "@nextui-org/react";
+import { NavbarItemsProps } from "../../../../common/types";
+import CentredLayout from "../../../ui/centredLayout";
+import ThemeToggler from "../../../shared/themeToggler";
+
+export default function DesktopNavbar({
+  navbarItems,
+}: Readonly<{ navbarItems: NavbarItemsProps[] }>) {
+  return (
+    <div className="sticky top-0 z-50 w-full bg-white">
+      <CentredLayout>
+        <nav className="flex flex-row items-center justify-between gap-6">
+          <div className="flex items-center gap-6">
+            <Link href="/">
+              <img
+                src="https://i.imgur.com/iqq372D.png"
+                className="w-16 invert"
+              />
+            </Link>
+
+            <ul className="flex-row items-center hidden gap-6 lg:flex">
+              {navbarItems.map((element, index) => (
+                <li key={index}>
+                  <Link
+                    className="block font-normal text-gray-900 hover:text-blue-700"
+                    href={element.link}
+                  >
+                    {element.label}
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </div>
+
+          <div className="flex items-start justify-start ">
+            <ThemeToggler />
+          </div>
+        </nav>
+      </CentredLayout>
+    </div>
+  );
+}

--- a/src/components/partials/navbar/index.tsx
+++ b/src/components/partials/navbar/index.tsx
@@ -1,46 +1,19 @@
 import { useTranslation } from "react-i18next";
 import { NavbarItemsProps } from "../../../common/types";
-import CentredLayout from "../../ui/centredLayout";
-import { Link } from "@nextui-org/react";
-import ThemeToggler from "../../shared/themeToggler";
+import { useMediaQuery } from "react-responsive";
+import MobileNavbar from "./mobile";
+import DesktopNavbar from "./desktop";
 
 export default function Navbar() {
+  const isMobile = useMediaQuery({ query: "(max-width: 1024px)" });
   const { t } = useTranslation();
   const navbarItems: NavbarItemsProps[] = t("navbar", {
     returnObjects: true,
   }) as NavbarItemsProps[];
 
-  return (
-    <div className="sticky top-0 z-50 w-full bg-white">
-      <CentredLayout>
-        <nav className="flex flex-row items-center justify-between gap-6">
-          <div className="flex items-center gap-6">
-            <Link href="/">
-              <img
-                src="https://i.imgur.com/iqq372D.png"
-                className="w-16 invert"
-              />
-            </Link>
-
-            <ul className="flex flex-row items-center gap-4">
-              {navbarItems.map((element, index) => (
-                <li key={index}>
-                  <Link
-                    className="block font-normal text-gray-900 hover:text-blue-700"
-                    href={element.link}
-                  >
-                    {element.label}
-                  </Link>
-                </li>
-              ))}
-            </ul>
-          </div>
-
-          <div className="flex items-start justify-start ">
-            <ThemeToggler />
-          </div>
-        </nav>
-      </CentredLayout>
-    </div>
+  return isMobile ? (
+    <MobileNavbar navbarItems={navbarItems} />
+  ) : (
+    <DesktopNavbar navbarItems={navbarItems} />
   );
 }

--- a/src/components/partials/navbar/mobile/index.tsx
+++ b/src/components/partials/navbar/mobile/index.tsx
@@ -1,0 +1,62 @@
+import {
+  Link,
+  Navbar,
+  NavbarBrand,
+  NavbarContent,
+  NavbarMenu,
+  NavbarMenuItem,
+  NavbarMenuToggle,
+} from "@nextui-org/react";
+import { NavbarItemsProps } from "../../../../common/types";
+import ThemeToggler from "../../../shared/themeToggler";
+import { useReducer } from "react";
+import { scrollToTop } from "../../../../common/utils";
+
+export default function MobileNavbar({
+  navbarItems,
+}: Readonly<{ navbarItems: NavbarItemsProps[] }>) {
+  const [isMenuOpen, setIsMenuOpen] = useReducer(
+    (current: boolean) => !current,
+    false
+  );
+
+  return (
+    <Navbar
+      onMenuOpenChange={setIsMenuOpen}
+      isMenuOpen={isMenuOpen}
+      position="sticky"
+      maxWidth="2xl"
+    >
+      <NavbarContent justify="start">
+        <NavbarBrand>
+          {" "}
+          <img src="https://i.imgur.com/iqq372D.png" className="w-16 invert" />
+        </NavbarBrand>
+      </NavbarContent>
+      <NavbarContent justify="center">
+        <ThemeToggler />
+      </NavbarContent>
+      <NavbarContent justify="end">
+        <NavbarMenuToggle
+          aria-label={isMenuOpen ? "Close menu" : "Open menu"}
+        />
+      </NavbarContent>
+      <NavbarMenu>
+        {navbarItems.map((item: NavbarItemsProps, index: number) => (
+          <NavbarMenuItem key={`${index}`}>
+            <Link
+              color="foreground"
+              href={item.link}
+              onClick={() => {
+                scrollToTop();
+                setIsMenuOpen();
+              }}
+            >
+              {item.label}
+            </Link>
+          </NavbarMenuItem>
+        ))}
+      </NavbarMenu>
+    </Navbar>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -15,12 +15,7 @@
 .pause {
   animation-play-state: paused;
 }
-.sharedGrid {
-  grid-template-columns: 500px 1fr;
-}
-.secondGrid {
-  grid-template-columns: 1fr 500px;
-}
+
 .erpGrid {
   grid-template-columns: repeat(auto-fill, minmax(350px, 1fr));
 }

--- a/src/views/Home/index.tsx
+++ b/src/views/Home/index.tsx
@@ -9,7 +9,7 @@ import TextileErpFeatures from "../../components/TextileErpFeatures";
 export default function Home() {
   const { t } = useTranslation();
   return (
-    <div className="flex flex-col gap-44">
+    <div className="flex flex-col gap-24 lg:gap-44">
       <Helmet>
         <title>{t("helmetPagesDescription.home.pageTitle")}</title>
         <meta


### PR DESCRIPTION
for responsive view, i created a mobile navbar to be shown in mobile view,  remove the carousel from the hero section and center the titles , for features section and textile section , i removed the css classes and created them using inline tailwind classes so i can use the lg: on them , and changes the contact us form to be in the center of the image, for the footer i just made the socials and sitemap in a flex col instead of flex-row