### PR TITLE
fix:scroll-to-top-link-on-buttons

### DIFF
--- a/src/components/heroSection/index.tsx
+++ b/src/components/heroSection/index.tsx
@@ -1,4 +1,4 @@
-import { Button } from "@nextui-org/react";
+import { Button, Link } from "@nextui-org/react";
 import Navbar from "../partials/navbar";
 import CentredLayout from "../ui/centredLayout";
 
@@ -35,8 +35,15 @@ export default function HeroSection() {
                   {t("heroSection.paragraph")}
                 </p>
                 <div className="flex gap-3">
-                  <Button color="default">{t("heroSection.moreButton")}</Button>
-                  <Button color="default" variant="bordered">
+                  <Button as={Link} href="/erp" color="default">
+                    {t("heroSection.moreButton")}
+                  </Button>
+                  <Button
+                    as={Link}
+                    href="/demo"
+                    color="default"
+                    variant="bordered"
+                  >
                     {t("heroSection.demoButton")}
                   </Button>
                 </div>

--- a/src/components/partials/navbar/desktop/index.tsx
+++ b/src/components/partials/navbar/desktop/index.tsx
@@ -2,6 +2,7 @@ import { Link } from "@nextui-org/react";
 import { NavbarItemsProps } from "../../../../common/types";
 import CentredLayout from "../../../ui/centredLayout";
 import ThemeToggler from "../../../shared/themeToggler";
+import { scrollToTop } from "../../../../common/utils";
 
 export default function DesktopNavbar({
   navbarItems,
@@ -24,6 +25,7 @@ export default function DesktopNavbar({
                   <Link
                     className="block font-normal text-gray-900 hover:text-blue-700"
                     href={element.link}
+                    onClick={() => scrollToTop()}
                   >
                     {element.label}
                   </Link>


### PR DESCRIPTION
For the hero section, add href attributes to the buttons and call the scrollToTop function in the navbar. This ensures that when a user navigates to another page, the new page loads from the top.